### PR TITLE
Increase Openmrs timeout in apache conf

### DIFF
--- a/resources/bahmni-proxy.conf
+++ b/resources/bahmni-proxy.conf
@@ -33,7 +33,7 @@ ProxyPass /ipd http://ipd/ipd
 ProxyPassReverse /ipd http://ipd/ipd
 
 # OpenMRS
-ProxyPass /openmrs http://openmrs:8080/openmrs
+ProxyPass /openmrs http://openmrs:8080/openmrs connectiontimeout=120 timeout=120
 ProxyPassReverse /openmrs http://openmrs:8080/openmrs
 
 #Bahmni Web


### PR DESCRIPTION
https://msfprojects.atlassian.net/browse/MOBN-2468

**Description**
By default, Apache has a 60-second timeout. To prevent 502 proxy errors with OpenMRS, we need to explicitly increase the timeout setting.

**Test**
Changes are tested in jmeter for Qa Amman lite
<img width="1728" alt="Screenshot 2024-09-02 at 9 53 54 AM" src="https://github.com/user-attachments/assets/3b446bc1-9f70-4f64-825f-4b6f520b71e1">
